### PR TITLE
fix: corrupted rows and scalar $in no longer break a collection's queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ A MongoDB-like client backed by SQLite. Use a familiar MongoDB API with the simp
 - **MongoDB-compatible API** — `insertOne`, `findOne`, `updateOne`, `deleteOne`, `find`, `aggregate`, and more
 - **SQLite persistence** — single file, zero configuration, works offline
 - **Automatic `_id` generation** — UUID assigned on insert if not provided
-- **WAL mode** — Write-Ahead Logging for better concurrent read access
+- **WAL mode** — Write-Ahead Logging for better concurrent read access, on by default
+- **Shared connections** — opt into one pooled connection per file per process
 - **Rich query operators** — `$eq`, `$gt`, `$in`, `$and`, `$or`, `$elemMatch`, `$regex`, and more
 - **Update operators** — `$set`, `$inc`, `$push`, `$pull`, `$addToSet`, `$mul`, and more
 - **Indexing** — create, list, and drop indexes including unique and compound indexes
 - **Change streams** — real-time change tracking via `collection.watch()`
-- **JSON safety** — validates documents before insert and recovers from corrupted data
+- **JSON safety** — validates documents before insert, and a corrupted row can't break queries for the rest of the collection
 - **TypeScript** — fully typed with strict mode
 
 ## Installation
@@ -105,6 +106,43 @@ const users = client.collection('users');
 await users.insertOne({ name: 'Alice', age: 30 });
 await client.close();
 ```
+
+### Connection options
+
+```typescript
+const client = new MongoLite({
+  filePath: './myapp.sqlite',
+  WAL: true,          // Write-Ahead Logging. Default: true
+  busyTimeout: 5000,  // ms to wait for a lock before SQLITE_BUSY. Default: 5000
+  shared: true,       // reuse one connection per file in this process. Default: false
+  readOnly: false,
+  verbose: false,
+});
+```
+
+#### Sharing one connection across a process
+
+Applications often end up with several clients pointing at the same database file
+— a module-level client, a background job, a request handler — each opening its
+own connection, and each then hand-rolling an instance cache to avoid the
+resulting lock contention. `shared: true` moves that into the library:
+
+```typescript
+// Both resolve to the same file, so they share a single SQLite connection.
+const a = new MongoLite({ filePath: './app.sqlite', shared: true });
+const b = new MongoLite({ filePath: './app.sqlite', shared: true });
+
+await a.close(); // b keeps working — the handle is reference counted
+await b.close(); // last holder out actually closes it
+```
+
+Connections are only shared when the resolved path *and* every setting that
+changes the handle's behaviour match. `:memory:` databases are never shared,
+since two `:memory:` opens are two unrelated databases.
+
+This dedupes connections **within a process only**. Separate processes each get
+their own, so cross-process contention is handled by WAL mode and `busyTimeout`
+instead.
 
 ### In-memory (tests / ephemeral)
 

--- a/docs/JSON_SAFETY.md
+++ b/docs/JSON_SAFETY.md
@@ -68,3 +68,40 @@ interface CorruptedDocument {
 ```
 
 This allows your application to detect and handle data integrity issues gracefully rather than throwing unexpected exceptions.
+
+## Corrupted Rows Don't Break Queries
+
+The marker above covers documents MongoLite *parses in JavaScript*. Filtered
+queries have a separate hazard: they compile to SQL using SQLite's json1
+functions (`json_extract`, `json_each`), and those raise `malformed JSON` as soon
+as they evaluate a row whose stored data isn't valid JSON — **including rows that
+could never have matched the filter**. Without a guard, one corrupted document
+makes every filtered read against that collection fail, so a single bad row is an
+outage for the whole collection.
+
+Compiled filters are therefore guarded with `json_valid(data)`. Corruption
+degrades to "that document is missing from results" instead of "this collection is
+unqueryable".
+
+Two consequences worth knowing:
+
+- **Unfiltered reads still surface corrupt rows**, in the degraded marker form
+  above. `find({})` doesn't invoke any json1 function, so there's nothing to
+  guard against — and leaving it unguarded keeps `deleteMany({})` able to purge
+  corrupt rows.
+- **Skipped rows are quiet.** Reads keep working, which also means corruption
+  stops announcing itself.
+
+### Finding and repairing corrupt rows
+
+```typescript
+const invalid = await collection.findInvalidJson();
+// [{ _id: 'abc', data: '{"name":"broken",' }]
+
+for (const row of invalid) {
+  await collection.deleteOne({ _id: row._id }); // _id lookups bypass json1
+}
+
+// Cheap enough to run as a scheduled health check:
+const badRows = await collection.countInvalidJson();
+```

--- a/src/adapters/node-sqlite.ts
+++ b/src/adapters/node-sqlite.ts
@@ -1,5 +1,20 @@
 import { DatabaseSync } from 'node:sqlite';
+import path from 'node:path';
 import type { IDatabaseAdapter, MongoLiteOptions } from '../db.js';
+import {
+  ConnectionRegistry,
+  DEFAULT_BUSY_TIMEOUT_MS,
+  buildConnectionKey,
+  isShareablePath,
+} from '../utils/connection-registry.js';
+
+/** Shared `node:sqlite` handles for this process, keyed by connection identity. */
+const sharedConnections = new ConnectionRegistry<DatabaseSync>();
+
+/** Exposed for tests and diagnostics. */
+export function sharedConnectionCount(): number {
+  return sharedConnections.size;
+}
 
 /** Scalar values `node:sqlite` accepts as bound statement parameters. */
 type SqlBindValue = string | number | bigint | null | NodeJS.ArrayBufferView;
@@ -37,6 +52,8 @@ export class NodeSqliteAdapter implements IDatabaseAdapter {
   private readonly verbose: boolean;
   private readonly readOnly: boolean;
   private readonly WAL: boolean;
+  private readonly busyTimeout: number;
+  private readonly shareKey: string | null;
   private openPromise: Promise<void> | null = null;
 
   /**
@@ -45,17 +62,35 @@ export class NodeSqliteAdapter implements IDatabaseAdapter {
    * `better-sqlite3` adapter's `MongoLiteOptions`.
    */
   constructor(dbPathOrOptions: string | MongoLiteOptions) {
+    let shared: boolean;
+
     if (typeof dbPathOrOptions === 'string') {
       this.filePath = dbPathOrOptions;
       this.verbose = false;
       this.readOnly = false;
-      this.WAL = false;
+      this.WAL = true;
+      this.busyTimeout = DEFAULT_BUSY_TIMEOUT_MS;
+      shared = false;
     } else {
       this.filePath = dbPathOrOptions.filePath;
       this.verbose = dbPathOrOptions.verbose || false;
       this.readOnly = dbPathOrOptions.readOnly || false;
-      this.WAL = dbPathOrOptions.WAL || true;
+      this.WAL = dbPathOrOptions.WAL ?? true;
+      this.busyTimeout = dbPathOrOptions.busyTimeout ?? DEFAULT_BUSY_TIMEOUT_MS;
+      shared = dbPathOrOptions.shared ?? false;
     }
+
+    this.shareKey =
+      shared && isShareablePath(this.filePath)
+        ? buildConnectionKey({
+            backend: 'node:sqlite',
+            filePath: path.resolve(this.filePath),
+            readOnly: this.readOnly,
+            WAL: this.WAL,
+            busyTimeout: this.busyTimeout,
+            verbose: this.verbose,
+          })
+        : null;
   }
 
   /**
@@ -71,47 +106,63 @@ export class NodeSqliteAdapter implements IDatabaseAdapter {
 
     this.openPromise = new Promise((resolve, reject) => {
       try {
-        this.db = new DatabaseSync(this.filePath, { readOnly: this.readOnly });
+        // Only runs on a genuinely new connection — when sharing, an existing
+        // handle already has its pragmas and UDFs applied.
+        const openConnection = (): DatabaseSync => {
+          const db = new DatabaseSync(this.filePath, { readOnly: this.readOnly });
 
-        if (this.WAL && !this.readOnly) {
-          this.db.exec('PRAGMA journal_mode = WAL');
-        }
-
-        // Register regexp UDF for $regex operator support.
-        // WARNING: Patterns are compiled via JavaScript RegExp. User-supplied patterns that are
-        // not validated for catastrophic backtracking (ReDoS) could block the event loop.
-        // Avoid using untrusted/unvalidated patterns with $regex in security-sensitive contexts.
-        this.db.function(
-          'regexp',
-          { deterministic: true },
-          (pattern: unknown, value: unknown): number => {
-            if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
-            try {
-              return new RegExp(pattern).test(String(value)) ? 1 : 0;
-            } catch {
-              return 0;
-            }
+          if (this.WAL && !this.readOnly) {
+            db.exec('PRAGMA journal_mode = WAL');
           }
-        );
 
-        // Register regexp_flags UDF for $regex with $options support
-        this.db.function(
-          'regexp_flags',
-          { deterministic: true },
-          (pattern: unknown, flags: unknown, value: unknown): number => {
-            if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
-            try {
-              const f = typeof flags === 'string' ? flags : '';
-              return new RegExp(pattern, f).test(String(value)) ? 1 : 0;
-            } catch {
-              return 0;
-            }
+          // Wait rather than immediately throwing SQLITE_BUSY when another
+          // connection (often another process) holds a lock.
+          if (this.busyTimeout > 0) {
+            db.exec(`PRAGMA busy_timeout = ${this.busyTimeout}`);
           }
-        );
 
-        if (this.verbose) {
-          console.log(`SQLite database opened (node:sqlite): ${this.filePath}`);
-        }
+          // Register regexp UDF for $regex operator support.
+          // WARNING: Patterns are compiled via JavaScript RegExp. User-supplied patterns that are
+          // not validated for catastrophic backtracking (ReDoS) could block the event loop.
+          // Avoid using untrusted/unvalidated patterns with $regex in security-sensitive contexts.
+          db.function(
+            'regexp',
+            { deterministic: true },
+            (pattern: unknown, value: unknown): number => {
+              if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
+              try {
+                return new RegExp(pattern).test(String(value)) ? 1 : 0;
+              } catch {
+                return 0;
+              }
+            }
+          );
+
+          // Register regexp_flags UDF for $regex with $options support
+          db.function(
+            'regexp_flags',
+            { deterministic: true },
+            (pattern: unknown, flags: unknown, value: unknown): number => {
+              if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
+              try {
+                const f = typeof flags === 'string' ? flags : '';
+                return new RegExp(pattern, f).test(String(value)) ? 1 : 0;
+              } catch {
+                return 0;
+              }
+            }
+          );
+
+          if (this.verbose) {
+            console.log(`SQLite database opened (node:sqlite): ${this.filePath}`);
+          }
+
+          return db;
+        };
+
+        this.db = this.shareKey
+          ? sharedConnections.acquire(this.shareKey, openConnection)
+          : openConnection();
 
         resolve();
       } catch (err) {
@@ -191,9 +242,21 @@ export class NodeSqliteAdapter implements IDatabaseAdapter {
     }
     if (this.db) {
       try {
-        this.db.close();
+        // When shared, only the last holder actually closes the handle.
+        const isLastHolder = this.shareKey
+          ? sharedConnections.release(this.shareKey, this.db)
+          : true;
+
+        if (isLastHolder) {
+          this.db.close();
+        }
+
         if (this.verbose) {
-          console.log(`SQLite database closed (node:sqlite): ${this.filePath}`);
+          console.log(
+            isLastHolder
+              ? `SQLite database closed (node:sqlite): ${this.filePath}`
+              : `SQLite database released (still in use): ${this.filePath}`
+          );
         }
       } catch (err) {
         console.error(`Error closing database ${this.filePath}:`, (err as Error).message);

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -439,7 +439,7 @@ export class MongoLiteCollection<T extends DocumentWithId> {
 
     // Find the document first (only one)
     const paramsForSelect: unknown[] = [];
-    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildWhereClause'](
+    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildGuardedWhereClause'](
       filter,
       paramsForSelect
     );
@@ -580,14 +580,15 @@ export class MongoLiteCollection<T extends DocumentWithId> {
             const currentValue = this.getNestedValue(currentDoc, path);
             const arr: unknown[] = Array.isArray(currentValue) ? currentValue : [];
             const items =
-              typeof value === 'object' && value !== null && '$each' in value && Array.isArray(value.$each)
+              typeof value === 'object' &&
+              value !== null &&
+              '$each' in value &&
+              Array.isArray(value.$each)
                 ? value.$each
                 : [value];
             let changed = false;
             for (const item of items) {
-              const alreadyPresent = arr.some(
-                (el) => JSON.stringify(el) === JSON.stringify(item)
-              );
+              const alreadyPresent = arr.some((el) => JSON.stringify(el) === JSON.stringify(item));
               if (!alreadyPresent) {
                 arr.push(item);
                 changed = true;
@@ -735,7 +736,7 @@ export class MongoLiteCollection<T extends DocumentWithId> {
   async updateMany(filter: Filter<T>, update: UpdateFilter<T>): Promise<UpdateResult> {
     await this.ensureTable();
     const paramsForSelect: unknown[] = [];
-    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildWhereClause'](
+    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildGuardedWhereClause'](
       filter,
       paramsForSelect
     );
@@ -837,7 +838,10 @@ export class MongoLiteCollection<T extends DocumentWithId> {
               const currentValue = this.getNestedValue(currentDoc, path);
               const arr: unknown[] = Array.isArray(currentValue) ? currentValue : [];
               const items =
-                typeof value === 'object' && value !== null && '$each' in value && Array.isArray(value.$each)
+                typeof value === 'object' &&
+                value !== null &&
+                '$each' in value &&
+                Array.isArray(value.$each)
                   ? value.$each
                   : [value];
               let changed = false;
@@ -1198,7 +1202,7 @@ export class MongoLiteCollection<T extends DocumentWithId> {
     await this.ensureTable();
 
     const paramsForDelete: unknown[] = [];
-    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildWhereClause'](
+    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildGuardedWhereClause'](
       filter,
       paramsForDelete
     );
@@ -1237,7 +1241,7 @@ export class MongoLiteCollection<T extends DocumentWithId> {
     await this.ensureTable();
 
     const paramsForDelete: unknown[] = [];
-    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildWhereClause'](
+    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildGuardedWhereClause'](
       filter,
       paramsForDelete
     );
@@ -1273,13 +1277,50 @@ export class MongoLiteCollection<T extends DocumentWithId> {
     await this.ensureTable();
 
     const paramsForCount: unknown[] = [];
-    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildWhereClause'](
+    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildGuardedWhereClause'](
       filter,
       paramsForCount
     );
     const countSql = `SELECT COUNT(*) as count FROM "${this.name}" WHERE ${whereClause}`;
 
     const result = await this.db.get<{ count: number }>(countSql, paramsForCount);
+    return result?.count || 0;
+  }
+
+  /**
+   * Finds rows whose stored `data` column is not valid JSON.
+   *
+   * Filtered queries deliberately skip these rows — see
+   * `FindCursor.buildGuardedWhereClause` — so that one corrupted document can't
+   * make the whole collection unqueryable. That keeps reads working, but it also
+   * means such rows quietly stop appearing in results. This is the way to find
+   * them so they can be repaired or deleted (`deleteOne({ _id })` works on them,
+   * since `_id` lookups don't go through json1 functions).
+   *
+   * Intended for integrity checks and ops tooling rather than hot paths: it scans
+   * the table and returns the raw column text, not parsed documents.
+   *
+   * @returns The `_id` and raw stored text of every invalid row.
+   */
+  async findInvalidJson(): Promise<{ _id: string; data: string }[]> {
+    await this.ensureTable();
+
+    return this.db.all<{ _id: string; data: string }>(
+      `SELECT _id, data FROM "${this.name}" WHERE json_valid(data) = 0`
+    );
+  }
+
+  /**
+   * Counts rows whose stored `data` column is not valid JSON.
+   * Cheap enough to run on a schedule as a health check.
+   * @see findInvalidJson
+   */
+  async countInvalidJson(): Promise<number> {
+    await this.ensureTable();
+
+    const result = await this.db.get<{ count: number }>(
+      `SELECT COUNT(*) as count FROM "${this.name}" WHERE json_valid(data) = 0`
+    );
     return result?.count || 0;
   }
 
@@ -1322,9 +1363,7 @@ export class MongoLiteCollection<T extends DocumentWithId> {
 
     // Update by _id when available to ensure we modify the exact document we found
     const updateFilter: Filter<T> =
-      existingId !== undefined && existingId !== null
-        ? ({ _id: existingId } as Filter<T>)
-        : filter;
+      existingId !== undefined && existingId !== null ? ({ _id: existingId } as Filter<T>) : filter;
 
     const updateResult = await this.updateOne(updateFilter, update, { upsert });
 
@@ -1389,10 +1428,7 @@ export class MongoLiteCollection<T extends DocumentWithId> {
     projCursor.project(projection as Projection<T>);
     // Since we already deleted, apply projection manually from the full doc
     const fullDocRec = existingFullDoc as Record<string, unknown>;
-    return this.applyAggregateProjection(
-      fullDocRec,
-      projection as Record<string, unknown>
-    ) as T;
+    return this.applyAggregateProjection(fullDocRec, projection as Record<string, unknown>) as T;
   }
 
   /**
@@ -1745,7 +1781,8 @@ export class MongoLiteCollection<T extends DocumentWithId> {
                 const nums = groupDocs
                   .map((doc) => this.getNestedValue(doc, fieldName))
                   .filter((v) => typeof v === 'number') as number[];
-                groupResult[field] = nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : null;
+                groupResult[field] =
+                  nums.length > 0 ? nums.reduce((a, b) => a + b, 0) / nums.length : null;
               }
               break;
             }
@@ -1755,7 +1792,8 @@ export class MongoLiteCollection<T extends DocumentWithId> {
                 const vals = groupDocs
                   .map((doc) => this.getNestedValue(doc, fieldName))
                   .filter((v) => v !== undefined && v !== null);
-                groupResult[field] = vals.length > 0 ? vals.reduce((a, b) => (a < b ? a : b)) : null;
+                groupResult[field] =
+                  vals.length > 0 ? vals.reduce((a, b) => (a < b ? a : b)) : null;
               }
               break;
             }
@@ -1765,7 +1803,8 @@ export class MongoLiteCollection<T extends DocumentWithId> {
                 const vals = groupDocs
                   .map((doc) => this.getNestedValue(doc, fieldName))
                   .filter((v) => v !== undefined && v !== null);
-                groupResult[field] = vals.length > 0 ? vals.reduce((a, b) => (a > b ? a : b)) : null;
+                groupResult[field] =
+                  vals.length > 0 ? vals.reduce((a, b) => (a > b ? a : b)) : null;
               }
               break;
             }
@@ -1870,7 +1909,12 @@ export class MongoLiteCollection<T extends DocumentWithId> {
 
       const docValue = this.getNestedValue(doc, key);
 
-      if (typeof value === 'object' && value !== null && !(value instanceof RegExp) && !(value instanceof Date)) {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        !(value instanceof RegExp) &&
+        !(value instanceof Date)
+      ) {
         const ops = value as Record<string, unknown>;
         const hasOps = Object.keys(ops).some((k) => k.startsWith('$'));
         if (hasOps) {

--- a/src/cursors/findCursor.ts
+++ b/src/cursors/findCursor.ts
@@ -241,9 +241,16 @@ export class FindCursor<T extends DocumentWithId> {
     return `(json_valid(${root}) AND json_type(${root}, ${arrayPath}) = 'array')`;
   }
 
-  /** Negation of {@link buildIsArrayCheck}. */
+  /**
+   * Negation of {@link buildIsArrayCheck} — but not just `!=`. When `arrayPath` doesn't exist
+   * in the document, `json_type` returns SQL NULL, and `NULL != 'array'` is itself NULL (falsy),
+   * not TRUE. That silently dropped missing-field documents from the "not array" branch of
+   * $in/$nin/$all, even though they're exactly the case `IS NULL` handling downstream expects to
+   * see. `IS NOT` treats NULL as distinct from 'array', so missing fields correctly count as
+   * "not an array" here.
+   */
   private buildIsNotArrayCheck(root: string, arrayPath: string): string {
-    return `(json_valid(${root}) AND json_type(${root}, ${arrayPath}) != 'array')`;
+    return `(json_valid(${root}) AND json_type(${root}, ${arrayPath}) IS NOT 'array')`;
   }
 
   /**

--- a/src/cursors/findCursor.ts
+++ b/src/cursors/findCursor.ts
@@ -3,6 +3,12 @@ import type { IDatabaseAdapter } from '../db.js';
 import { applyProjectionToDocument } from '../utils/projection.js';
 
 /**
+ * Matches compiled clauses that invoke SQLite's json1 functions, which are the
+ * ones that throw on malformed JSON. See `buildGuardedWhereClause`.
+ */
+const JSON1_FUNCTION_PATTERN = /\bjson_(?:extract|each)\s*\(/i;
+
+/**
  * Safely parses JSON data with fallback mechanisms for malformed JSON.
  * @param jsonString The JSON string to parse
  * @param context Optional context for error messages and recovery
@@ -192,18 +198,19 @@ export class FindCursor<T extends DocumentWithId> {
 
     // For non-Date values, handle both array and non-array fields
     const arrayPath = this.parseJsonPath(field);
-    const isArrayCheck = `json_type(json_extract(${elementPrefix}, ${arrayPath})) = 'array'`;
+    const isArrayCheck = this.buildIsArrayCheck(elementPrefix, arrayPath);
+    const eachArg = this.buildJsonEachArg(elementPrefix, arrayPath);
     const placeholders = value.map(() => '?').join(',');
 
     let arrayCondition: string;
     let nonArrayCondition: string;
 
     if (operator === '$in') {
-      arrayCondition = `EXISTS (SELECT 1 FROM json_each(json_extract(${elementPrefix}, ${arrayPath})) WHERE json_each.value IN (${placeholders}))`;
+      arrayCondition = `EXISTS (SELECT 1 FROM json_each(${eachArg}) WHERE json_each.value IN (${placeholders}))`;
       nonArrayCondition = `(${jsonPath} IN (${placeholders}))`;
     } else {
       // $nin
-      arrayCondition = `NOT EXISTS (SELECT 1 FROM json_each(json_extract(${elementPrefix}, ${arrayPath})) WHERE json_each.value IN (${placeholders}))`;
+      arrayCondition = `NOT EXISTS (SELECT 1 FROM json_each(${eachArg}) WHERE json_each.value IN (${placeholders}))`;
       nonArrayCondition = `(${jsonPath} NOT IN (${placeholders}) OR ${jsonPath} IS NULL)`;
     }
 
@@ -213,8 +220,43 @@ export class FindCursor<T extends DocumentWithId> {
 
     return `(
       (${isArrayCheck} AND ${arrayCondition}) OR
-      (json_type(json_extract(${elementPrefix}, ${arrayPath})) != 'array' AND ${nonArrayCondition})
+      (${this.buildIsNotArrayCheck(elementPrefix, arrayPath)} AND ${nonArrayCondition})
     )`;
+  }
+
+  /**
+   * SQL testing whether the value at `arrayPath` is a JSON array.
+   *
+   * Uses `json_type`'s two-argument form. The one-argument form —
+   * `json_type(json_extract(root, path))` — re-parses the *extracted value* as
+   * JSON, which raises `malformed JSON` for any plain string field: for
+   * `{"role":"admin"}` `json_extract` yields the bare text `admin`, and
+   * `json_type('admin')` is not valid JSON. That made `$in`/`$nin`/`$all`/
+   * `$elemMatch` throw on every non-array field, on healthy data.
+   *
+   * The two-argument form also classifies correctly where the one-argument form
+   * lied: a string field holding `"[1,2]"` reported as `array` rather than `text`.
+   */
+  private buildIsArrayCheck(root: string, arrayPath: string): string {
+    return `(json_valid(${root}) AND json_type(${root}, ${arrayPath}) = 'array')`;
+  }
+
+  /** Negation of {@link buildIsArrayCheck}. */
+  private buildIsNotArrayCheck(root: string, arrayPath: string): string {
+    return `(json_valid(${root}) AND json_type(${root}, ${arrayPath}) != 'array')`;
+  }
+
+  /**
+   * Builds a safe argument for `json_each(...)`.
+   *
+   * SQLite evaluates a table-valued function inside a correlated subquery even
+   * when a preceding `AND` term (such as the is-array check) is false, so
+   * guarding *outside* the call isn't enough — `json_each('admin')` still runs
+   * and throws. The guard therefore has to live inside the argument: anything
+   * that isn't a valid JSON array becomes an empty array, which yields no rows.
+   */
+  private buildJsonEachArg(root: string, arrayPath: string): string {
+    return `CASE WHEN json_valid(${root}) AND json_type(${root}, ${arrayPath}) = 'array' THEN json_extract(${root}, ${arrayPath}) ELSE '[]' END`;
   }
 
   /**
@@ -439,7 +481,8 @@ export class FindCursor<T extends DocumentWithId> {
     params: unknown[]
   ): string {
     const arrayPath = this.parseJsonPath(field);
-    const arrayTypeCheck = `json_type(json_extract(data, ${arrayPath})) = 'array'`;
+    const arrayTypeCheck = this.buildIsArrayCheck('data', arrayPath);
+    const eachArg = this.buildJsonEachArg('data', arrayPath);
 
     if (operator === '$all') {
       if (Array.isArray(value) && value.length > 0) {
@@ -459,11 +502,11 @@ export class FindCursor<T extends DocumentWithId> {
                 objectConditions.push(`json_extract(json_each.value, '$.${key}') = ?`);
               }
               const condition = objectConditions.join(' AND ');
-              return `EXISTS (SELECT 1 FROM json_each(json_extract(data, ${arrayPath})) WHERE ${condition})`;
+              return `EXISTS (SELECT 1 FROM json_each(${eachArg}) WHERE ${condition})`;
             } else {
               // For simple values, use direct comparison
               params.push(toSQLiteValue(item));
-              return `EXISTS (SELECT 1 FROM json_each(json_extract(data, ${arrayPath})) WHERE json_each.value = ?)`;
+              return `EXISTS (SELECT 1 FROM json_each(${eachArg}) WHERE json_each.value = ?)`;
             }
           })
           .join(' AND ');
@@ -494,11 +537,11 @@ export class FindCursor<T extends DocumentWithId> {
                   objectConditions.push(`json_extract(json_each.value, '$.${key}') = ?`);
                 }
                 const condition = objectConditions.join(' AND ');
-                return `EXISTS (SELECT 1 FROM json_each(json_extract(data, ${arrayPath})) WHERE ${condition})`;
+                return `EXISTS (SELECT 1 FROM json_each(${eachArg}) WHERE ${condition})`;
               } else {
                 // For scalar values
                 params.push(toSQLiteValue(item));
-                return `EXISTS (SELECT 1 FROM json_each(json_extract(data, ${arrayPath})) WHERE json_each.value = ?)`;
+                return `EXISTS (SELECT 1 FROM json_each(${eachArg}) WHERE json_each.value = ?)`;
               }
             })
             .join(' OR ');
@@ -512,7 +555,7 @@ export class FindCursor<T extends DocumentWithId> {
     } else if (operator === '$elemMatch') {
       let elemMatchSubquery = `EXISTS (
         SELECT 1 
-        FROM json_each(json_extract(data, ${arrayPath})) as array_elements 
+        FROM json_each(${eachArg}) as array_elements 
         WHERE `;
 
       if (typeof value === 'object' && value !== null) {
@@ -713,9 +756,43 @@ export class FindCursor<T extends DocumentWithId> {
     return conditions.length > 0 ? conditions.join(' AND ') : '1=1';
   }
 
+  /**
+   * Wraps a compiled WHERE clause so that a single corrupted row can't take out
+   * every filtered query on the collection.
+   *
+   * SQLite's json1 functions (`json_extract`, `json_each`) raise
+   * `SqliteError: malformed JSON` as soon as they evaluate a row whose `data`
+   * column isn't valid JSON — including rows that would never have matched the
+   * filter anyway. One bad document therefore fails *all* filtered reads against
+   * that collection, not just the ones that would have returned it.
+   *
+   * Prefixing with `json_valid(data)` lets SQLite short-circuit those rows before
+   * any json1 function touches them, so corruption degrades to "this document is
+   * missing from results" rather than "this collection is unqueryable". Use
+   * {@link MongoLiteCollection.findInvalidJson} to find and repair the offenders.
+   *
+   * Applied only at the top level, and only when json1 functions are genuinely
+   * present, both deliberately:
+   * - `$not`/`$nor` compile their sub-clauses into `NOT (...)`. A guard nested
+   *   inside one would invert to `NOT (0 AND …)` — making corrupt rows *match* a
+   *   negated filter.
+   * - An empty filter compiles to `1=1`, touches no json1 function, and so can't
+   *   throw. Leaving it unguarded keeps `deleteMany({})` able to purge corrupt
+   *   rows, which is the escape hatch for cleaning them up.
+   */
+  private buildGuardedWhereClause(filter: Filter<T>, params: unknown[]): string {
+    const whereClause = this.buildWhereClause(filter, params);
+
+    if (!JSON1_FUNCTION_PATTERN.test(whereClause)) {
+      return whereClause;
+    }
+
+    return `json_valid(data) AND (${whereClause})`;
+  }
+
   private buildSelectQuery(filter: Filter<T>): { sql: string; params: unknown[] } {
     const params: unknown[] = [];
-    const whereClause = this.buildWhereClause(filter, params);
+    const whereClause = this.buildGuardedWhereClause(filter, params);
     const sql = `SELECT _id, data FROM "${this.collectionName}" WHERE ${whereClause}`;
 
     if (this.options.verbose) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,22 @@
 import Database from 'better-sqlite3';
 import type { Statement } from 'better-sqlite3';
+import path from 'node:path';
+import {
+  ConnectionRegistry,
+  DEFAULT_BUSY_TIMEOUT_MS,
+  buildConnectionKey,
+  isShareablePath,
+} from './utils/connection-registry.js';
+
+export { DEFAULT_BUSY_TIMEOUT_MS };
+
+/** Shared `better-sqlite3` handles for this process, keyed by connection identity. */
+const sharedConnections = new ConnectionRegistry<Database.Database>();
+
+/** Exposed for tests and diagnostics. */
+export function sharedConnectionCount(): number {
+  return sharedConnections.size;
+}
 
 /**
  * Common interface for database adapters.
@@ -18,7 +35,24 @@ export interface MongoLiteOptions {
   filePath: string;
   verbose?: boolean;
   readOnly?: boolean;
-  WAL?: boolean; // Add Write-Ahead Logging option
+  /** Write-Ahead Logging. Defaults to `true`. */
+  WAL?: boolean;
+  /**
+   * How long (ms) SQLite waits for a lock held by another connection before
+   * throwing `SQLITE_BUSY`. Defaults to {@link DEFAULT_BUSY_TIMEOUT_MS}; set to
+   * `0` to fail immediately.
+   */
+  busyTimeout?: number;
+  /**
+   * Reuse a single underlying SQLite connection across every instance in this
+   * process that resolves to the same database file and settings, instead of
+   * opening one connection per instance. Reference counted — `close()` only
+   * closes the real handle once the last holder releases it.
+   *
+   * Ignored for `:memory:` databases, which are private to their connection.
+   * Defaults to `false`.
+   */
+  shared?: boolean;
 }
 
 /**
@@ -31,6 +65,8 @@ export class SQLiteDB implements IDatabaseAdapter {
   private readonly verbose: boolean;
   private readonly readOnly: boolean;
   private readonly WAL: boolean;
+  private readonly busyTimeout: number;
+  private readonly shareKey: string | null;
   private openPromise: Promise<void> | null = null;
 
   /**
@@ -39,17 +75,35 @@ export class SQLiteDB implements IDatabaseAdapter {
    * Use ':memory:' for an in-memory database.
    */
   constructor(dbPathOrOptions: string | MongoLiteOptions) {
+    let shared: boolean;
+
     if (typeof dbPathOrOptions === 'string') {
       this.filePath = dbPathOrOptions;
       this.verbose = false;
       this.readOnly = false;
-      this.WAL = false;
+      this.WAL = true;
+      this.busyTimeout = DEFAULT_BUSY_TIMEOUT_MS;
+      shared = false;
     } else {
       this.filePath = dbPathOrOptions.filePath;
       this.verbose = dbPathOrOptions.verbose || false;
       this.readOnly = dbPathOrOptions.readOnly || false;
-      this.WAL = dbPathOrOptions.WAL || true;
+      this.WAL = dbPathOrOptions.WAL ?? true;
+      this.busyTimeout = dbPathOrOptions.busyTimeout ?? DEFAULT_BUSY_TIMEOUT_MS;
+      shared = dbPathOrOptions.shared ?? false;
     }
+
+    this.shareKey =
+      shared && isShareablePath(this.filePath)
+        ? buildConnectionKey({
+            backend: 'better-sqlite3',
+            filePath: path.resolve(this.filePath),
+            readOnly: this.readOnly,
+            WAL: this.WAL,
+            busyTimeout: this.busyTimeout,
+            verbose: this.verbose,
+          })
+        : null;
   }
 
   /**
@@ -67,53 +121,69 @@ export class SQLiteDB implements IDatabaseAdapter {
 
     this.openPromise = new Promise((resolve, reject) => {
       try {
-        const options: Database.Options = {
-          readonly: this.readOnly,
-          verbose: this.verbose ? console.log : undefined,
+        // Only runs on a genuinely new connection — when sharing, an existing
+        // handle already has its pragmas and UDFs applied.
+        const openConnection = (): Database.Database => {
+          const options: Database.Options = {
+            readonly: this.readOnly,
+            verbose: this.verbose ? console.log : undefined,
+          };
+
+          const db = new Database(this.filePath, options);
+
+          // Enable Write-Ahead Logging if requested
+          if (this.WAL && !this.readOnly) {
+            db.pragma('journal_mode = WAL');
+          }
+
+          // Wait rather than immediately throwing SQLITE_BUSY when another
+          // connection (often another process) holds a lock.
+          if (this.busyTimeout > 0) {
+            db.pragma(`busy_timeout = ${this.busyTimeout}`);
+          }
+
+          // Register regexp UDF for $regex operator support.
+          // WARNING: Patterns are compiled via JavaScript RegExp. User-supplied patterns that are
+          // not validated for catastrophic backtracking (ReDoS) could block the event loop.
+          // Avoid using untrusted/unvalidated patterns with $regex in security-sensitive contexts.
+          db.function(
+            'regexp',
+            { deterministic: true },
+            (pattern: unknown, value: unknown): number => {
+              if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
+              try {
+                return new RegExp(pattern).test(String(value)) ? 1 : 0;
+              } catch {
+                return 0;
+              }
+            }
+          );
+
+          // Register regexp_flags UDF for $regex with $options support
+          db.function(
+            'regexp_flags',
+            { deterministic: true },
+            (pattern: unknown, flags: unknown, value: unknown): number => {
+              if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
+              try {
+                const f = typeof flags === 'string' ? flags : '';
+                return new RegExp(pattern, f).test(String(value)) ? 1 : 0;
+              } catch {
+                return 0;
+              }
+            }
+          );
+
+          if (this.verbose) {
+            console.log(`SQLite database opened: ${this.filePath}`);
+          }
+
+          return db;
         };
 
-        this.db = new Database(this.filePath, options);
-
-        // Enable Write-Ahead Logging if requested
-        if (this.WAL && !this.readOnly) {
-          this.db.pragma('journal_mode = WAL');
-        }
-
-        // Register regexp UDF for $regex operator support.
-        // WARNING: Patterns are compiled via JavaScript RegExp. User-supplied patterns that are
-        // not validated for catastrophic backtracking (ReDoS) could block the event loop.
-        // Avoid using untrusted/unvalidated patterns with $regex in security-sensitive contexts.
-        this.db.function(
-          'regexp',
-          { deterministic: true },
-          (pattern: unknown, value: unknown): number => {
-            if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
-            try {
-              return new RegExp(pattern).test(String(value)) ? 1 : 0;
-            } catch {
-              return 0;
-            }
-          }
-        );
-
-        // Register regexp_flags UDF for $regex with $options support
-        this.db.function(
-          'regexp_flags',
-          { deterministic: true },
-          (pattern: unknown, flags: unknown, value: unknown): number => {
-            if (typeof pattern !== 'string' || value === null || value === undefined) return 0;
-            try {
-              const f = typeof flags === 'string' ? flags : '';
-              return new RegExp(pattern, f).test(String(value)) ? 1 : 0;
-            } catch {
-              return 0;
-            }
-          }
-        );
-
-        if (this.verbose) {
-          console.log(`SQLite database opened: ${this.filePath}`);
-        }
+        this.db = this.shareKey
+          ? sharedConnections.acquire(this.shareKey, openConnection)
+          : openConnection();
 
         resolve();
       } catch (err) {
@@ -228,9 +298,21 @@ export class SQLiteDB implements IDatabaseAdapter {
     }
     if (this.db) {
       try {
-        this.db.close();
+        // When shared, only the last holder actually closes the handle.
+        const isLastHolder = this.shareKey
+          ? sharedConnections.release(this.shareKey, this.db)
+          : true;
+
+        if (isLastHolder) {
+          this.db.close();
+        }
+
         if (this.verbose) {
-          console.log(`SQLite database closed: ${this.filePath}`);
+          console.log(
+            isLastHolder
+              ? `SQLite database closed: ${this.filePath}`
+              : `SQLite database released (still in use): ${this.filePath}`
+          );
         }
       } catch (err) {
         console.error(`Error closing database ${this.filePath}:`, (err as Error).message);

--- a/src/utils/connection-registry.ts
+++ b/src/utils/connection-registry.ts
@@ -1,0 +1,139 @@
+/**
+ * Process-wide registry of open SQLite handles, keyed by connection identity.
+ *
+ * Consumers frequently end up with several `MongoLite` instances pointing at the
+ * same database file — a module-level client here, a background job there, each
+ * calling `new MongoLite(path)` independently. Every one of those opens its own
+ * SQLite connection, which turns same-process reads/writes into needless lock
+ * contention and forces each consumer to hand-roll its own instance cache.
+ *
+ * When `shared` is enabled, adapters acquire their underlying handle through this
+ * registry instead of opening one directly, so N adapter instances against the
+ * same identity share a single connection. Each adapter still tracks its own
+ * open/closed state; the handle is only really closed once the last holder
+ * releases it (reference counting), so one consumer calling `close()` can't pull
+ * the connection out from under another.
+ *
+ * Note this only dedupes connections *within a process*. Separate processes (e.g.
+ * worker threads spawned as child processes, or a job runner forking workers)
+ * each get their own registry and therefore their own connection — cross-process
+ * contention is handled by WAL mode and `busy_timeout`, not by sharing.
+ */
+
+/**
+ * Default `busy_timeout`, in milliseconds, applied to new connections.
+ *
+ * Lives here rather than in `db.ts` so the `node:sqlite` adapter can read it
+ * without importing that module — `db.ts` pulls in `better-sqlite3`, which is an
+ * optional dependency and may not be installed.
+ */
+export const DEFAULT_BUSY_TIMEOUT_MS = 5000;
+
+interface RegistryEntry<THandle> {
+  handle: THandle;
+  refCount: number;
+}
+
+export class ConnectionRegistry<THandle> {
+  private readonly entries = new Map<string, RegistryEntry<THandle>>();
+
+  /**
+   * Returns the handle registered for `key`, opening one via `open()` on first
+   * use. Increments the reference count for existing entries.
+   */
+  public acquire(key: string, open: () => THandle): THandle {
+    const existing = this.entries.get(key);
+    if (existing) {
+      existing.refCount++;
+      return existing.handle;
+    }
+
+    const handle = open();
+    this.entries.set(key, { handle, refCount: 1 });
+    return handle;
+  }
+
+  /**
+   * Drops one reference to `key`.
+   * @returns `true` when the caller held the last reference and is therefore
+   * responsible for closing the handle; `false` while other holders remain.
+   */
+  public release(key: string, handle: THandle): boolean {
+    const entry = this.entries.get(key);
+
+    // Untracked handle (never shared, or already fully released) — the caller
+    // owns it outright and should close it.
+    if (!entry || entry.handle !== handle) {
+      return true;
+    }
+
+    entry.refCount--;
+    if (entry.refCount > 0) {
+      return false;
+    }
+
+    this.entries.delete(key);
+    return true;
+  }
+
+  /** Live reference count for `key`; 0 when nothing holds it. */
+  public refCount(key: string): number {
+    return this.entries.get(key)?.refCount ?? 0;
+  }
+
+  /** Number of distinct shared handles currently open. */
+  public get size(): number {
+    return this.entries.size;
+  }
+
+  /**
+   * Forgets every entry without closing the handles.
+   * Intended for test isolation, not for production teardown.
+   */
+  public clear(): void {
+    this.entries.clear();
+  }
+}
+
+/**
+ * Builds a stable registry key. Connections may only be shared when every
+ * setting that affects the handle's behaviour matches, so each of these is part
+ * of the identity rather than just the file path.
+ */
+export function buildConnectionKey(parts: {
+  backend: string;
+  filePath: string;
+  readOnly: boolean;
+  WAL: boolean;
+  busyTimeout: number;
+  verbose: boolean;
+}): string {
+  return JSON.stringify([
+    parts.backend,
+    parts.filePath,
+    parts.readOnly,
+    parts.WAL,
+    parts.busyTimeout,
+    parts.verbose,
+  ]);
+}
+
+/**
+ * Whether a database path is eligible for sharing.
+ *
+ * `:memory:` databases are private to their connection — two `:memory:` opens are
+ * two unrelated databases, so sharing them would silently merge state that
+ * callers expect to be isolated. Anonymous temp databases (empty path) behave the
+ * same way.
+ */
+export function isShareablePath(filePath: string): boolean {
+  const normalised = filePath.trim().toLowerCase();
+  if (normalised === '' || normalised === ':memory:') {
+    return false;
+  }
+  // file: URIs opt into sharing only when not explicitly in-memory.
+  if (normalised.startsWith('file:') && normalised.includes('mode=memory')) {
+    return false;
+  }
+  return true;
+}

--- a/tests/collection.find.test.ts
+++ b/tests/collection.find.test.ts
@@ -507,9 +507,14 @@ describe('MongoLiteCollection - Find Operations', () => {
     });
 
     it('should find documents using $nin operator for top-level field', async () => {
-      const docs = await collection.find({ value: { $nin: [10, 30, 50] } }).toArray(); // Should only leave value: 20
-      assert.strictEqual(docs.length, 2);
-      assert.ok(docs.every((d) => d.value === 20));
+      const docs = await collection.find({ value: { $nin: [10, 30, 50] } }).toArray();
+      // MongoDB semantics: $nin matches documents whose value is not in the list,
+      // *including* those where the field is null or absent — the same treatment
+      // the $ne test above documents. emptyDoc (value: null) therefore matches
+      // alongside the two value: 20 documents.
+      assert.strictEqual(docs.length, 3);
+      assert.ok(docs.every((d) => d.value === 20 || d.value === null));
+      assert.ok(docs.some((d) => d.value === null));
     });
 
     it('should find documents using $in operator for array field (element match)', async () => {
@@ -1260,10 +1265,7 @@ describe('MongoLiteCollection - Find Operations', () => {
       it('should handle $and with $in operator', async () => {
         const docs = await collection
           .find({
-            $and: [
-              { 'something.a': { $in: [1, 2] } },
-              { 'something.b': { $in: [2, 3] } },
-            ],
+            $and: [{ 'something.a': { $in: [1, 2] } }, { 'something.b': { $in: [2, 3] } }],
           })
           .toArray();
 

--- a/tests/collection.json-corruption.test.ts
+++ b/tests/collection.json-corruption.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Regression coverage for corrupted `data` columns.
+ *
+ * SQLite's json1 functions (`json_extract`, `json_each`) throw
+ * `malformed JSON` as soon as they evaluate a row whose `data` isn't valid JSON —
+ * even a row that could never have matched the filter. Before the
+ * `json_valid(data)` guard, a single corrupted document made *every* filtered
+ * query against that collection fail, turning one bad row into a full outage for
+ * the collection.
+ *
+ * These tests corrupt a row deliberately (writing raw SQL, bypassing the
+ * library's own `safeJsonStringify` validation, which is exactly what an external
+ * writer or a partial write would do) and assert reads stay up.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { MongoLite, MongoLiteCollection, DocumentWithId } from '../src/index';
+
+interface UserDoc extends DocumentWithId {
+  name: string;
+  clientCode?: string;
+  role?: string;
+  tags?: string[];
+  items?: { k: string }[];
+  api?: { available?: boolean };
+}
+
+const COLLECTION = 'testCorruptionCollection';
+
+describe('MongoLiteCollection - corrupted JSON resilience', () => {
+  let client: MongoLite;
+  let collection: MongoLiteCollection<UserDoc>;
+
+  /** Writes an unparseable value straight into the data column. */
+  const corruptRow = async (id: string, raw = '{"name":"broken",') => {
+    await client.database.run(`INSERT INTO "${COLLECTION}" (_id, data) VALUES (?, ?)`, [id, raw]);
+  };
+
+  beforeEach(async () => {
+    client = new MongoLite(':memory:');
+    await client.connect();
+    collection = client.collection<UserDoc>(COLLECTION);
+
+    await collection.insertOne({
+      _id: 'good-1',
+      name: 'Alice',
+      clientCode: 'ACME',
+      role: 'admin',
+      tags: ['a', 'b'],
+      api: { available: true },
+    });
+    await collection.insertOne({
+      _id: 'good-2',
+      name: 'Bob',
+      clientCode: 'BETA',
+      role: 'user',
+      tags: ['c'],
+      api: { available: false },
+    });
+
+    await corruptRow('bad-1');
+  });
+
+  afterEach(async () => {
+    await client.close();
+  });
+
+  describe('filtered reads survive a corrupt row', () => {
+    it('find() on a top-level field returns the valid documents', async () => {
+      const results = await collection.find({ clientCode: 'ACME' }).toArray();
+
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0]._id, 'good-1');
+    });
+
+    it('find() on a nested field does not throw', async () => {
+      const results = await collection.find({ 'api.available': true }).toArray();
+
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0]._id, 'good-1');
+    });
+
+    it('handles $in, $nin, $or, $regex and $all', async () => {
+      const inResults = await collection.find({ role: { $in: ['admin', 'user'] } }).toArray();
+      assert.strictEqual(inResults.length, 2);
+
+      const ninResults = await collection.find({ role: { $nin: ['admin'] } }).toArray();
+      assert.deepStrictEqual(
+        ninResults.map((r) => r._id),
+        ['good-2']
+      );
+
+      const orResults = await collection
+        .find({ $or: [{ clientCode: 'ACME' }, { clientCode: 'BETA' }] })
+        .toArray();
+      assert.strictEqual(orResults.length, 2);
+
+      const regexResults = await collection.find({ name: { $regex: '^Ali' } }).toArray();
+      assert.strictEqual(regexResults.length, 1);
+
+      const allResults = await collection.find({ tags: { $all: ['c'] } }).toArray();
+      assert.deepStrictEqual(
+        allResults.map((r) => r._id),
+        ['good-2']
+      );
+    });
+
+    it('handles $elemMatch over an array of objects', async () => {
+      await collection.insertOne({
+        _id: 'good-3',
+        name: 'Carol',
+        items: [{ k: 'wanted' }],
+      } as UserDoc);
+
+      const results = await collection.find({ items: { $elemMatch: { k: 'wanted' } } }).toArray();
+
+      assert.deepStrictEqual(
+        results.map((r) => r._id),
+        ['good-3']
+      );
+    });
+
+    it('findOne() does not throw', async () => {
+      const found = await collection.findOne({ name: 'Bob' });
+
+      assert.ok(found);
+      assert.strictEqual(found._id, 'good-2');
+    });
+
+    it('countDocuments() excludes the corrupt row', async () => {
+      assert.strictEqual(await collection.countDocuments({ role: { $exists: true } }), 2);
+    });
+
+    it('updateMany() does not throw and skips the corrupt row', async () => {
+      const result = await collection.updateMany(
+        { role: { $exists: true } },
+        { $set: { role: 'archived' } }
+      );
+
+      assert.strictEqual(result.matchedCount, 2);
+    });
+
+    it('aggregate() with a leading $match does not throw', async () => {
+      const results = await collection
+        .aggregate([{ $match: { clientCode: 'ACME' } }, { $count: 'total' }])
+        .toArray();
+
+      assert.deepStrictEqual(results, [{ total: 1 }]);
+    });
+
+    it('stays up when every row is corrupt', async () => {
+      await collection.deleteMany({});
+      await corruptRow('bad-only', '<<not json at all>>');
+
+      assert.deepStrictEqual(await collection.find({ clientCode: 'ACME' }).toArray(), []);
+    });
+  });
+
+  describe('negated filters must not match corrupt rows', () => {
+    // The guard is applied only at the top level for this reason: nested inside a
+    // `NOT (...)` it would invert to `NOT (0 AND ...)` = true, so corrupt rows
+    // would start matching every negated filter.
+    it('$nor does not return the corrupt row', async () => {
+      const results = await collection.find({ $nor: [{ clientCode: 'ACME' }] }).toArray();
+
+      assert.deepStrictEqual(
+        results.map((r) => r._id),
+        ['good-2']
+      );
+    });
+
+    it('$ne does not return the corrupt row', async () => {
+      const results = await collection.find({ clientCode: { $ne: 'ACME' } }).toArray();
+
+      assert.deepStrictEqual(
+        results.map((r) => r._id),
+        ['good-2']
+      );
+    });
+
+    it('$not does not return the corrupt row', async () => {
+      const results = await collection.find({ $not: { clientCode: 'ACME' } }).toArray();
+
+      assert.deepStrictEqual(
+        results.map((r) => r._id),
+        ['good-2']
+      );
+    });
+  });
+
+  describe('corrupt rows remain reachable for cleanup', () => {
+    it('findInvalidJson() reports them with their raw contents', async () => {
+      const invalid = await collection.findInvalidJson();
+
+      assert.strictEqual(invalid.length, 1);
+      assert.strictEqual(invalid[0]._id, 'bad-1');
+      assert.strictEqual(invalid[0].data, '{"name":"broken",');
+    });
+
+    it('countInvalidJson() counts them', async () => {
+      assert.strictEqual(await collection.countInvalidJson(), 1);
+
+      await corruptRow('bad-2', 'null-ish {');
+      assert.strictEqual(await collection.countInvalidJson(), 2);
+    });
+
+    it('reports zero for a healthy collection', async () => {
+      await collection.deleteOne({ _id: 'bad-1' });
+
+      assert.strictEqual(await collection.countInvalidJson(), 0);
+      assert.deepStrictEqual(await collection.findInvalidJson(), []);
+    });
+
+    it('deleteOne({ _id }) can remove a corrupt row', async () => {
+      const result = await collection.deleteOne({ _id: 'bad-1' });
+
+      assert.strictEqual(result.deletedCount, 1);
+      assert.strictEqual(await collection.countInvalidJson(), 0);
+    });
+
+    it('deleteMany({}) purges corrupt rows', async () => {
+      // The empty filter is intentionally left unguarded so this escape hatch
+      // keeps working — otherwise corrupt rows could never be cleared in bulk.
+      await collection.deleteMany({});
+
+      assert.strictEqual(await collection.estimatedDocumentCount(), 0);
+    });
+
+    it('unfiltered find() still surfaces the row, in degraded form', async () => {
+      const results = await collection.find({}).toArray();
+      const corrupt = results.find((r) => r._id === 'bad-1') as
+        (UserDoc & { __mongoLiteCorrupted?: boolean }) | undefined;
+
+      assert.ok(corrupt, 'unfiltered reads should still expose the corrupt row');
+      assert.strictEqual(corrupt.__mongoLiteCorrupted, true);
+    });
+  });
+});

--- a/tests/connection-sharing.test.ts
+++ b/tests/connection-sharing.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Coverage for opt-in connection sharing, the `busy_timeout` pragma, and the WAL
+ * default.
+ *
+ * Consumers commonly end up with several clients pointing at one database file —
+ * a module-level client, a background job, a request handler — each opening its
+ * own connection and then hand-rolling an instance cache to avoid the resulting
+ * lock contention. `shared: true` moves that dedup into the library.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { MongoLite, DocumentWithId } from '../src/index';
+import { sharedConnectionCount } from '../src/adapters/node-sqlite.js';
+
+interface TestDoc extends DocumentWithId {
+  name: string;
+}
+
+let tempDir: string;
+let dbPath: string;
+
+describe('connection sharing', () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mongolite-share-'));
+    dbPath = path.join(tempDir, 'shared.sqlite');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reuses one underlying connection for the same file', async () => {
+    const before = sharedConnectionCount();
+
+    const a = new MongoLite({ filePath: dbPath, shared: true });
+    const b = new MongoLite({ filePath: dbPath, shared: true });
+    await a.connect();
+    await b.connect();
+
+    assert.strictEqual(sharedConnectionCount(), before + 1, 'expected a single shared handle');
+
+    await a.close();
+    await b.close();
+  });
+
+  it('resolves equivalent paths to the same connection', async () => {
+    const a = new MongoLite({ filePath: dbPath, shared: true });
+    const b = new MongoLite({
+      filePath: path.join(tempDir, '.', 'shared.sqlite'),
+      shared: true,
+    });
+    const before = sharedConnectionCount();
+    await a.connect();
+    await b.connect();
+
+    assert.strictEqual(sharedConnectionCount(), before + 1);
+
+    await a.close();
+    await b.close();
+  });
+
+  it('sees writes made through a sibling client immediately', async () => {
+    const writer = new MongoLite({ filePath: dbPath, shared: true });
+    const reader = new MongoLite({ filePath: dbPath, shared: true });
+    await writer.connect();
+    await reader.connect();
+
+    await writer.collection<TestDoc>('docs').insertOne({ _id: '1', name: 'written' });
+    const found = await reader.collection<TestDoc>('docs').findOne({ _id: '1' });
+
+    assert.strictEqual(found?.name, 'written');
+
+    await writer.close();
+    await reader.close();
+  });
+
+  it('keeps the connection usable after a sibling closes', async () => {
+    const a = new MongoLite({ filePath: dbPath, shared: true });
+    const b = new MongoLite({ filePath: dbPath, shared: true });
+    await a.connect();
+    await b.connect();
+
+    await a.collection<TestDoc>('docs').insertOne({ _id: '1', name: 'first' });
+
+    // Without reference counting this would close the handle out from under b.
+    await a.close();
+
+    const stillWorks = await b.collection<TestDoc>('docs').findOne({ _id: '1' });
+    assert.strictEqual(stillWorks?.name, 'first');
+
+    await b.close();
+  });
+
+  it('releases the handle once the last holder closes', async () => {
+    const before = sharedConnectionCount();
+
+    const a = new MongoLite({ filePath: dbPath, shared: true });
+    const b = new MongoLite({ filePath: dbPath, shared: true });
+    await a.connect();
+    await b.connect();
+
+    await a.close();
+    assert.strictEqual(sharedConnectionCount(), before + 1, 'still held by b');
+
+    await b.close();
+    assert.strictEqual(sharedConnectionCount(), before, 'fully released');
+  });
+
+  it('does not share unless asked', async () => {
+    const before = sharedConnectionCount();
+
+    const a = new MongoLite({ filePath: dbPath });
+    const b = new MongoLite({ filePath: dbPath });
+    await a.connect();
+    await b.connect();
+
+    assert.strictEqual(sharedConnectionCount(), before, 'sharing is opt-in');
+
+    await a.close();
+    await b.close();
+  });
+
+  it('never shares :memory: databases', async () => {
+    const before = sharedConnectionCount();
+
+    // Two :memory: opens are two unrelated databases; sharing them would merge
+    // state that callers expect to be isolated.
+    const a = new MongoLite({ filePath: ':memory:', shared: true });
+    const b = new MongoLite({ filePath: ':memory:', shared: true });
+    await a.connect();
+    await b.connect();
+
+    assert.strictEqual(sharedConnectionCount(), before);
+
+    await a.collection<TestDoc>('docs').insertOne({ _id: '1', name: 'only-in-a' });
+    assert.strictEqual(await b.collection<TestDoc>('docs').countDocuments({}), 0);
+
+    await a.close();
+    await b.close();
+  });
+
+  it('does not share across differing connection settings', async () => {
+    const seed = new MongoLite({ filePath: dbPath });
+    await seed.connect();
+    await seed.collection<TestDoc>('docs').insertOne({ _id: '1', name: 'seed' });
+    await seed.close();
+
+    const before = sharedConnectionCount();
+    const rw = new MongoLite({ filePath: dbPath, shared: true });
+    const ro = new MongoLite({ filePath: dbPath, shared: true, readOnly: true });
+    await rw.connect();
+    await ro.connect();
+
+    // readOnly changes how the handle behaves, so it must not be shared with a
+    // read-write holder.
+    assert.strictEqual(sharedConnectionCount(), before + 2);
+
+    await rw.close();
+    await ro.close();
+  });
+});
+
+describe('connection pragmas', () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mongolite-pragma-'));
+    dbPath = path.join(tempDir, 'pragma.sqlite');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('applies a default busy_timeout', async () => {
+    const client = new MongoLite({ filePath: dbPath });
+    await client.connect();
+
+    const row = await client.database.get<{ timeout: number }>('PRAGMA busy_timeout');
+    assert.strictEqual(row?.timeout, 5000);
+
+    await client.close();
+  });
+
+  it('honours an explicit busyTimeout', async () => {
+    const client = new MongoLite({ filePath: dbPath, busyTimeout: 250 });
+    await client.connect();
+
+    const row = await client.database.get<{ timeout: number }>('PRAGMA busy_timeout');
+    assert.strictEqual(row?.timeout, 250);
+
+    await client.close();
+  });
+
+  it('enables WAL by default, including for the string constructor', async () => {
+    // The string form previously left WAL off while the docs advertised it as a
+    // default, so file-backed databases silently ran in rollback-journal mode.
+    const client = new MongoLite(dbPath);
+    await client.connect();
+
+    const row = await client.database.get<{ journal_mode: string }>('PRAGMA journal_mode');
+    assert.strictEqual(row?.journal_mode.toLowerCase(), 'wal');
+
+    await client.close();
+  });
+
+  it('allows WAL to be turned off', async () => {
+    // `WAL: false` was previously impossible to express: `options.WAL || true`
+    // collapsed it back to true.
+    const client = new MongoLite({ filePath: dbPath, WAL: false });
+    await client.connect();
+
+    const row = await client.database.get<{ journal_mode: string }>('PRAGMA journal_mode');
+    assert.notStrictEqual(row?.journal_mode.toLowerCase(), 'wal');
+
+    await client.close();
+  });
+});

--- a/tests/parity/scenarios/query-operators.scenarios.ts
+++ b/tests/parity/scenarios/query-operators.scenarios.ts
@@ -24,6 +24,13 @@ export const queryOperatorScenarios: ParityScenario<OpDoc>[] = [
   { description: '$lte matches lesser-or-equal values', seedDocs, operation: { kind: 'find', filter: { n: { $lte: 10 } } } },
   { description: '$in matches any listed value', seedDocs, operation: { kind: 'find', filter: { n: { $in: [10, 15] } } } },
   { description: '$nin excludes listed values', seedDocs, operation: { kind: 'find', filter: { n: { $nin: [10, 15] } } } },
+  // Scalar *string* fields specifically: the numeric cases above pass even with a
+  // broken is-array check, because a bare number is still valid JSON where a bare
+  // string is not. That asymmetry is why $in/$nin on string fields went unnoticed.
+  { description: '$in matches a scalar string field', seedDocs, operation: { kind: 'find', filter: { s: { $in: ['hello', 'world'] } } } },
+  { description: '$nin excludes values of a scalar string field', seedDocs, operation: { kind: 'find', filter: { s: { $nin: ['hello'] } } } },
+  { description: '$nin also matches documents missing the field', seedDocs, operation: { kind: 'find', filter: { opt: { $nin: ['present'] } } } },
+  { description: '$in matches an array field alongside scalars', seedDocs, operation: { kind: 'find', filter: { tags: { $in: ['b'] } } } },
   { description: '$all requires every listed array element present', seedDocs, operation: { kind: 'find', filter: { tags: { $all: ['a', 'b'] } } } },
   { description: '$exists: true matches documents with the field present', seedDocs, operation: { kind: 'find', filter: { opt: { $exists: true } } } },
   { description: '$exists: false matches documents missing the field', seedDocs, operation: { kind: 'find', filter: { opt: { $exists: false } } } },


### PR DESCRIPTION
Prompted by a production `SqliteError: malformed JSON` on a filtered `find()` against a SQLite-backed config cache. Investigating it turned up **two independent causes** of that same error, plus the connection-handling gaps that made the first one likelier.

## 1. One corrupted row broke every filtered query on the collection

`json_extract`/`json_each` raise `malformed JSON` as soon as they evaluate a row whose `data` isn't valid JSON — **including rows that could never have matched the filter**. So a single bad document didn't just go missing, it failed *every* filtered read against that collection. Unfiltered `find({})` kept working, which is what made it confusing to diagnose.

Compiled clauses are now guarded with `json_valid(data)`. Corruption degrades to "this document is missing from results" instead of "this collection is unqueryable".

Applied only at the top level and only when json1 functions are actually present — both deliberate, and both covered by tests:

- Nested inside `$not`/`$nor`, a guard inverts to `NOT (0 AND …)` and would make corrupt rows **match** negated filters.
- An empty filter compiles to `1=1`, touches no json1 function, and so can't throw. Leaving it unguarded is what keeps `deleteMany({})` able to purge corrupt rows.

## 2. `$in`/`$nin`/`$all`/`$elemMatch` threw on scalar string fields — no corruption needed

This one reproduces on a completely healthy collection:

```ts
await col.insertOne({ _id: 'a', role: 'admin' });
await col.find({ role: { $in: ['admin'] } }).toArray();  // throws: malformed JSON
```

The is-array check used `json_type(json_extract(data, path))`, which re-parses the *extracted value* as JSON. For `{"role":"admin"}`, `json_extract` returns the bare text `admin`, and `json_type('admin')` is not valid JSON.

Switched to the two-argument `json_type(data, path)` form — which the `$type` handling in this file already used, with a comment noting it's the correct one. It's also strictly more accurate: the old form reported a string containing `"[1,2]"` as an `array`.

Guarding *outside* the call isn't enough for `json_each`. SQLite evaluates a table-valued function in a correlated subquery even when a preceding `AND` term is false, so `json_each('admin')` still ran and threw. The guard therefore lives inside the argument, where anything that isn't a valid JSON array becomes `'[]'`.

**Why existing tests missed it:** the `$in`/`$nin` coverage only used numeric fields. A bare number is still valid JSON where a bare string is not, so the broken path was never exercised. Added scalar-string parity scenarios.

## 3. Connection handling

- **`shared: true`** — reuse one connection per resolved file per process, reference counted so one holder's `close()` can't pull the handle out from under another. This replaces the per-repo instance caches consumers were writing by hand. Opt-in, since it changes what `close()` does; worth defaulting on in a future major.
- **`busyTimeout`** (default 5000ms) — SQLite previously threw `SQLITE_BUSY` immediately instead of waiting for a lock held elsewhere.
- **WAL now actually defaults on.** `new MongoLite(path)` set `WAL = false`, so the most common usage ran in rollback-journal mode while the README advertised WAL as a default feature. The options form had the inverse bug — `options.WAL || true` collapsed `WAL: false` back to true, making it impossible to disable. Both now use `??`.

Sharing dedupes within a process only; separate processes rely on WAL + `busyTimeout`.

## Visibility

Rows the guard skips would otherwise stop announcing themselves, so `findInvalidJson()` and `countInvalidJson()` expose them for repair. `deleteOne({ _id })` works on corrupt rows, since `_id` lookups don't go through json1.

## Behaviour changes worth a look before merging

1. **`$nin` now matches documents whose field is null or absent**, per MongoDB semantics and consistent with how `$ne` already behaved here. One existing assertion encoded the old exclusion and has been updated with a comment.
2. **File-backed databases opened by path now use WAL**, which sets `journal_mode` persistently on the file.

## Testing

439 pass / 0 fail, plus `build`, `verify-build` and `test-third-party`.

Two caveats on what I could *not* verify locally, both environmental:

- **The parity suite didn't run** — `mongodb-memory-server` couldn't start (no MongoDB binary available). The new `$in`/`$nin` scenarios are therefore unverified against real MongoDB; CI should be the judge, particularly on the `$nin` null semantics above.
- `npm run lint` fails repo-wide on a Windows checkout (`core.autocrlf=true`, no `.gitattributes`, every file reads as CRLF), so I linted my changed files individually instead. Separately, the lint globs `src/**/*.ts` don't expand recursively under `sh`, so top-level files like `src/db.ts` and the parity scenarios aren't currently linted at all — flagging rather than fixing here.

## Not fixed here

`$elemMatch` with operator syntax on an array of scalars — `{ tags: { $elemMatch: { $eq: 'c' } } }` — still throws `malformed JSON`. It compiles to `json_extract(array_elements.value, '$.$eq')`, treating the operator as a field name. Same family of bug, but a distinct behavioural fix; left out to keep this reviewable. Object-shaped `$elemMatch` works and is covered.
