### PR TITLE
test: cover $nin against a field missing entirely, not just null

### DIFF
--- a/tests/operator-coverage.test.ts
+++ b/tests/operator-coverage.test.ts
@@ -45,6 +45,19 @@ const cases: OperatorCase[] = [
   { op: '$lte', description: '$lte matches lesser-or-equal values', filter: { n: { $lte: 10 } }, expectedIds: ['1'] },
   { op: '$in', description: '$in matches any listed value', filter: { n: { $in: [10, 15] } }, expectedIds: ['1', '3'] },
   { op: '$nin', description: '$nin excludes listed values', filter: { n: { $nin: [10, 15] } }, expectedIds: ['2'] },
+  // Regression for a bug where the SQL path silently excluded documents missing the field
+  // entirely (as opposed to holding it as an explicit `null`): json_type() returns SQL NULL
+  // for a path that doesn't exist, and `NULL != 'array'` is itself NULL, not TRUE, so the
+  // "field is not an array" branch never ran and the accompanying `... IS NULL` fallback that
+  // was supposed to catch this case never got the chance to. Docs '2' and '3' have no `opt`
+  // key at all (see fixture above) — distinct from `mixed: null` on doc '3', which already
+  // worked because json_type() returns the string 'null' for an explicit null, not SQL NULL.
+  {
+    op: '$nin',
+    description: '$nin also matches documents missing the field entirely',
+    filter: { opt: { $nin: ['present'] } },
+    expectedIds: ['2', '3'],
+  },
   { op: '$all', description: '$all requires every listed element present', filter: { tags: { $all: ['a', 'b'] } }, expectedIds: ['1'] },
   { op: '$exists', description: '$exists matches documents with the field present', filter: { opt: { $exists: true } }, expectedIds: ['1'] },
   { op: '$not', description: '$not negates a nested operator', filter: { n: { $not: { $gt: 10 } } }, expectedIds: ['1'] },


### PR DESCRIPTION
## Description

Closes a gap that let the `$nin`-on-a-missing-field bug (fixed in #82) reach CI undetected by any locally-runnable test.

## Type of Change

- [x] Other (describe): Test coverage addition (no production code change)

## Changes Made

- Added a case to `tests/operator-coverage.test.ts` for `$nin` against a field that is **entirely absent** from a document, as opposed to explicitly `null`.

## Motivation & Context

`operator-coverage.test.ts` exists specifically to catch operators drifting between @semics-tech/mongolite's three query-evaluation paths — `find()`'s SQL builder, aggregation `$match`'s SQL first-stage, and aggregation `$match`'s in-memory evaluator — by running the same filter through all three and asserting they agree.

Its existing `$nin` case only used a field present on every document. The one other `$nin` test touching a sometimes-missing field (`collection.find.test.ts`) used a document with an **explicit `null`** value rather than an **omitted key**. That distinction mattered: SQLite's `json_type(data, path)` returns the string `'null'` for an explicit null, but returns SQL `NULL` when the key is absent — and `NULL != 'array'` evaluates to `NULL`, not `TRUE`. That's exactly what let the `$nin`/missing-field bug fixed in #82 slip past every local test and only get caught by the MongoDB parity suite (which needs network access to download a `mongod` binary, and wasn't runnable in that PR's environment).

## Testing

- [x] Existing tests pass (`npm test`)
- [x] New tests added to cover changes
- [x] Manual testing performed (describe below)

**Manual testing steps:**

1. Reverted `findCursor.ts` to its pre-#82-fix state and ran the new test case — it failed exactly as expected: `find()` and the SQL `$match` path both returned `[]`, while the in-memory `$match` path correctly returned the two missing-field documents, exposing the exact three-way divergence this test file is designed to catch.
2. Restored the fix and reran the full suite: 442 passing, 0 failing.

## Checklist

- [x] My code follows the project's style guidelines (`npm run lint`)
- [x] I have performed a self-review of my code
- [x] I have commented on complex or non-obvious sections of code
- [x] My changes generate no new warnings or errors
- [x] The build succeeds (`npm run build`)
- [x] I have documented my testing (automated and/or manual) in the **Testing** section above
- [ ] I have updated documentation where necessary

## Additional Notes

No production code changes — this PR only adds test coverage. The underlying fix already merged to `master` via #82.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VbLQHFfVAJm8NZy4QyvXai)_