### PR TITLE
ci: allow the release workflow to be triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  # Lets a maintainer re-fire the release from the Actions tab when a push
+  # to master never produced a run (e.g. a GitHub Actions outage swallowed
+  # the event) - there is otherwise no run to re-run in that situation.
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description

Adds `workflow_dispatch` to `release.yml` so the release can be re-fired by hand from the Actions tab.

Fixes #ISSUE_NUMBER
<!-- No linked issue - see Motivation & Context. -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (code improvement with no functional change)
- [ ] Documentation update
- [x] Other (describe): CI workflow trigger

## Changes Made

- `release.yml` now also triggers on `workflow_dispatch`, alongside the existing `push: branches: [master]`.

## Motivation & Context

`release.yml` only ran on push to master. Today's Actions outage silently dropped the push event for the merge of #84 (`1a08b4d`) — no workflow run was created for that commit at all, on any workflow, not just this one. Because GitHub can only re-run a run that exists, there was no way to recover except pushing a new commit to master.

`workflow_dispatch` gives a second way to fire the release when that happens again: from the Actions tab, no new commit required.

**Merging this PR also clears the immediate problem.** Merging is itself a push to master, which fires `release.yml` via its existing trigger. `semantic-release` computes the next version from every commit since the last tag (`v1.2.0`), not just the head commit, so it will pick up `#84`'s `feat(cli): …` commit and cut **1.3.0** — this PR's own commit is typed `ci`, which `.releaserc.json` maps to `release: false`, so it doesn't affect version selection either way.

## Testing

- [x] Existing tests pass (`npm test`) — unaffected, no application code touched.
- [ ] New tests added to cover changes — not applicable, workflow trigger only.
- [x] Manual testing performed (describe below)

**Manual testing steps:**

1. Validated the YAML is well-formed and `workflow_dispatch: {}` is accepted as an empty-input manual trigger.
2. Confirmed via the GitHub API that no run exists for `1a08b4d` on any workflow (`ci.yml`, `release.yml`), and that the last tag/npm-published version is `1.2.0` while master already has the `#84` feature commit — this is the gap this change closes.

## Checklist

- [x] My code follows the project's style guidelines (`npm run lint`)
- [x] I have performed a self-review of my code
- [x] I have commented on complex or non-obvious sections of code
- [x] My changes generate no new warnings or errors
- [x] The build succeeds (`npm run build`)
- [x] I have documented my testing (automated and/or manual) in the **Testing** section above
- [ ] I have updated documentation where necessary — not applicable

## Additional Notes

No application code or `package.json` version changed in this PR — the version bump to 1.3.0 happens automatically via `semantic-release` once this merges to master, exactly as it would have for #84 without the outage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XmY7ZAtFLEw9Cne4wyRceY)_