### PR TITLE
fix: FindCursor.count() ignores its filter and returns the whole collection count

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -192,6 +192,10 @@ Sorts results. Example: `{ age: -1, name: 1 }` (1 = ascending, -1 = descending).
 
 Specifies which fields to include or exclude in results.
 
+### `async count(): Promise<number>`
+
+Returns the number of documents matching the cursor's filter (like MongoDB's `cursor.count()`, it ignores `skip`/`limit` but never the filter).
+
 ---
 
 ## Indexing

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1276,15 +1276,7 @@ export class MongoLiteCollection<T extends DocumentWithId> {
   async countDocuments(filter: Filter<T> = {}): Promise<number> {
     await this.ensureTable();
 
-    const paramsForCount: unknown[] = [];
-    const whereClause = new FindCursor<T>(this.db, this.name, filter)['buildGuardedWhereClause'](
-      filter,
-      paramsForCount
-    );
-    const countSql = `SELECT COUNT(*) as count FROM "${this.name}" WHERE ${whereClause}`;
-
-    const result = await this.db.get<{ count: number }>(countSql, paramsForCount);
-    return result?.count || 0;
+    return this.find(filter).count();
   }
 
   /**

--- a/src/cursors/findCursor.ts
+++ b/src/cursors/findCursor.ts
@@ -155,10 +155,10 @@ export class FindCursor<T extends DocumentWithId> {
   constructor(
     private db: IDatabaseAdapter,
     private collectionName: string,
-    initialFilter: Filter<T>,
+    private readonly filter: Filter<T>,
     private readonly options: { verbose?: boolean } = {}
   ) {
-    this.queryParts = this.buildSelectQuery(initialFilter);
+    this.queryParts = this.buildSelectQuery(filter);
   }
 
   private parseJsonPath(path: string): string {
@@ -944,9 +944,10 @@ export class FindCursor<T extends DocumentWithId> {
    * @returns A promise that resolves to the count of matching documents.
    */
   public async count(): Promise<number> {
-    const whereClause = this.buildWhereClause({}, []);
+    const params: unknown[] = [];
+    const whereClause = this.buildGuardedWhereClause(this.filter, params);
     const countSql = `SELECT COUNT(*) as count FROM "${this.collectionName}" WHERE ${whereClause}`;
-    const result = await this.db.get<{ count: number }>(countSql);
+    const result = await this.db.get<{ count: number }>(countSql, params);
     return result?.count ?? 0; // Return 0 if result is undefined
   }
 }

--- a/tests/collection.index.test.ts
+++ b/tests/collection.index.test.ts
@@ -240,8 +240,23 @@ describe('Collection Indexing', async () => {
       tags: [],
     });
 
-    // Verify both documents exist
+    // A third document with a different age, so that the filtered count and
+    // the total collection count diverge — a regression test for count()
+    // ignoring its filter would pass with a stale assertion of 2 out of 2.
+    await usersCollection.insertOne({
+      name: 'Person 3',
+      email: 'person3@example.com',
+      age: 99,
+      address: { city: 'City 3', country: 'Country 3' },
+      tags: [],
+    });
+
+    // Verify both documents matching the filter are counted, not the whole collection
     const count = await usersCollection.find({ age: 30 }).count();
     expect(count).toBe(2);
+
+    // A filter matching nothing should count zero, not the whole collection
+    const zeroCount = await usersCollection.find({ age: 1000 }).count();
+    expect(zeroCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- `FindCursor.count()` built its WHERE clause from `{}` instead of the cursor's stored filter, and discarded the bound params before calling `db.get()` — so it always returned the total row count, regardless of the filter. `toArray()` on the same cursor was correct, which made the mismatch easy to miss.
- The cursor now stores its filter and `count()` reuses `buildGuardedWhereClause` (with its params), matching `toArray()` and keeping the corrupted-JSON guard consistent.
- `Collection.countDocuments()` now delegates to `find(filter).count()` instead of reaching into `FindCursor`'s private `buildGuardedWhereClause` via bracket notation.
- Added `FindCursor.count()` to `docs/API.md`.

## Test plan
- [x] Reworked the assertion in `tests/collection.index.test.ts` that previously couldn't fail (2 matching docs out of 2 total) — added a third document with a different `age` so filtered vs. total counts diverge, plus a zero-match case.
- [x] `npm test` — 669 passed, 4 skipped (pre-existing, unrelated), 0 failed.
- [x] `npm run build` and `npm run lint` — clean (only pre-existing `no-explicit-any` warnings in an unrelated file).

Fixes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)